### PR TITLE
fix the display of selection range that is off-by-one on prompt.

### DIFF
--- a/lib/CLI/Helpers.pm
+++ b/lib/CLI/Helpers.pm
@@ -370,10 +370,9 @@ sub menu {
 
     print $OUT "$question\n\n";
     my %ref = ();
-    my $id  = 1;
+    my $id  = 0;
     foreach my $key (sort keys %desc) {
-        $ref{$id} = $key;
-        $id++;
+        $ref{++$id} = $key;
     }
 
     my $choice;


### PR DESCRIPTION
A trivial example to demostrate the error:

```
[~/src/CLI-Helpers]
> perl -Ilib -MCLI::Helpers=:all -e 'prompt("pick one", menu => ["a".."e"])'
pick one

    1. a
    2. b
    3. c
    4. d
    5. e

Selection (1-6):

                 ^-- wrong
```
